### PR TITLE
Infra NodeSelector Tolerations

### DIFF
--- a/charts/cluster-acm/templates/MultiClusterHub.yaml
+++ b/charts/cluster-acm/templates/MultiClusterHub.yaml
@@ -35,4 +35,8 @@ spec:
 {{- end }}{{- end }}
   overrides: {}
   separateCertificateManagement: false
+{{- if .Values.acm.mch.infra }}
+  nodeSelector:
+    node-role.kubernetes.io/infra: ''
+{{- end }}
 {{- end }}{{- end }}{{- end }}

--- a/charts/cluster-acm/values-startx.yaml
+++ b/charts/cluster-acm/values-startx.yaml
@@ -9,6 +9,7 @@ context: &context
 acm:
   enabled: true
   mch:
+    infra: false ## set to true if infra is available
     enabled: true
     hooked: false
     name: "startx-mch"
@@ -71,6 +72,7 @@ operator:
       channel: "release-2.4"
       name: advanced-cluster-management
       csv: advanced-cluster-management
+      infra: false ## Set to true if infra nodes are available
       source: 
         name: redhat-operators
         namespace: openshift-marketplace

--- a/charts/cluster-acm/values.schema.json
+++ b/charts/cluster-acm/values.schema.json
@@ -134,6 +134,9 @@
                         },
                         "name": {
                             "type": "string"
+                        },
+                        "infra": {
+                            "type": "boolean"
                         }
                     }
                 }
@@ -216,6 +219,9 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "infra": {
+                                    "type": "boolean"
                                 }
                             }
                         },

--- a/charts/cluster-acs/templates/Central.yaml
+++ b/charts/cluster-acs/templates/Central.yaml
@@ -43,6 +43,14 @@ spec:
   egress:
     connectivityPolicy: Online
   scanner:
+  {{- if .Values.acs.infra }}
+    nodeSelector:
+      node-role.kubernetes.io/infra: ''
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists  
+  {{- end }}
   {{- if .Values.acs.scanner.enabled }}
     analyzer:
       scaling:

--- a/charts/cluster-acs/templates/Central.yaml
+++ b/charts/cluster-acs/templates/Central.yaml
@@ -1,13 +1,6 @@
 {{- if .Values.acs.enabled }}{{- if .Values.acs.central }}{{- if .Values.acs.central.enabled }}
 {{- $root := . -}}
 {{- $namespace := .Values.project.project.name | default "open-security-management" -}}
-
-
-
-
-
-
-
 apiVersion: platform.stackrox.io/v1alpha1
 kind: Central
 metadata:
@@ -39,6 +32,14 @@ spec:
     persistence:
       persistentVolumeClaim:
         claimName: stackrox-db
+    {{- if .Values.acs.infra }}
+    nodeSelector:
+      node-role.kubernetes.io/infra: ''
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+    {{- end }}
   egress:
     connectivityPolicy: Online
   scanner:

--- a/charts/cluster-acs/values-startx.yaml
+++ b/charts/cluster-acs/values-startx.yaml
@@ -8,12 +8,13 @@ context: &context
   app: startx-acs
 acs:
   enabled: true
+  infra: false ## set this to true if infra node available
   central:
     enabled: true
     hooked: false
     name: "startx"
   scanner:
-      enabled: true
+    enabled: true
 
 # Configuration of the project (see https://startxfr.github.io/helm-repository/charts/project)
 project: 
@@ -49,6 +50,7 @@ operator:
     <<: *context
   subscription:
     enabled: true
+    infra: false ## set this to true if infra node available
     name: "rhacs-operator"
     namespace: "openshift-operators"
     version: "v3.66.1"

--- a/charts/cluster-acs/values.schema.json
+++ b/charts/cluster-acs/values.schema.json
@@ -119,6 +119,9 @@
                             "type": "boolean"
                         }
                     }
+                },
+                "infra": {
+                    "type": "boolean"
                 }
             }
         },
@@ -199,6 +202,9 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "infra": {
+                                    "type": "boolean"
                                 }
                             }
                         },

--- a/charts/cluster-logging/templates/clusterLogging.yaml
+++ b/charts/cluster-logging/templates/clusterLogging.yaml
@@ -83,7 +83,7 @@ spec:
       schedule: {{ .schedule | default "30 3 * * *" | quote }}
       {{- if .resources }}
       resources:
-        {{- .resources | nindent 8 -}}
+        {{- .resources | toYaml | nindent 8 -}}
       {{- end }}
   {{- end }}{{- end }}{{- end }}
   {{- if .Values.logging.fluentd }}{{- if .Values.logging.fluentd.enabled }}

--- a/charts/cluster-logging/templates/clusterLogging.yaml
+++ b/charts/cluster-logging/templates/clusterLogging.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   managementState: {{ .Values.logging.managementState | default "Managed" | quote }}
   logStore:
-    type: "elasticsearch"  
+    type: "elasticsearch" 
     retentionPolicy: 
       application:
         maxAge: 1d
@@ -30,28 +30,52 @@ spec:
         maxAge: 7d
       audit:
         maxAge: 7d
-    {{- if .Values.logging.elasticsearch }}{{- if .Values.logging.elasticsearch.enabled }}{{- with .Values.logging.elasticsearch }}
+    {{- if .Values.logging.elasticsearch }}
+    {{- if .Values.logging.elasticsearch.enabled }}
+    {{- with .Values.logging.elasticsearch }}
     elasticsearch:
       nodeCount: {{ .replicas | default 3 }}
       {{- if .resources }}
       resources:
-        {{- .resources | nindent 8 -}}
+        {{- .resources | toYaml | nindent 8 }}
       {{- end }}
       redundancyPolicy: "SingleRedundancy"
       storage:
         storageClassName: {{ .storage.class | default "gp2" | quote }}
         size: {{ .storage.size | default "200G" | quote }}
-    {{- end }}{{- end }}{{- end }}
-  {{- if .Values.logging.kibana }}{{- if .Values.logging.kibana.enabled }}{{- with .Values.logging.kibana }}
+    {{- end }}
+    {{- if .Values.logging.infra }}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- if .Values.logging.kibana }}
+  {{- if .Values.logging.kibana.enabled }}
   visualization:
-    type: "kibana"  
+    type: "kibana"
+    {{- with .Values.logging.kibana }}
     kibana:
       replicas: {{ .replicas | default 1 }}
       {{- if .resources }}
       resources:
-        {{- .resources | nindent 8 -}}
+        {{- .resources | toYaml | nindent 8 }}
       {{- end }}
-  {{- end }}{{- end }}{{- end }}
+    {{- end }}
+    {{- if .Values.logging.infra }}
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      tolerations:
+      - key: "node-role.kubernetes.io/infra"
+        operator: "Exists"
+        effect: "NoSchedule"
+    {{- end }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.logging.curation }}{{- if .Values.logging.curation.enabled }}{{- with .Values.logging.curation }}
   curation:
     type: "curator"
@@ -62,16 +86,17 @@ spec:
         {{- .resources | nindent 8 -}}
       {{- end }}
   {{- end }}{{- end }}{{- end }}
-  {{- if .Values.logging.fluentd }}{{- if .Values.logging.fluentd.enabled }}{{- with .Values.logging.fluentd }}
+  {{- if .Values.logging.fluentd }}{{- if .Values.logging.fluentd.enabled }}
   collection:
     logs:
-      type: "fluentd"  
-      {{- if .resources }}
-      fluentd: 
-        resources:
-          {{- .resources | nindent 10 -}}
-      {{- else }}
-      fluentd: {}
+      type: "fluentd"
+      {{- with .Values.logging.fluentd}}
+      fluentd:
+        resources: {{ if .resources }}{{ .resources | toJson }}{{ else }}{}{{- end }}
       {{- end }}
-  {{- end }}{{- end }}{{- end }}
+        {{- if .Values.logging.infra }}
+        tolerations:
+          - operator: "Exists"
+        {{- end }}
+  {{- end }}{{- end }}
 {{- end }}

--- a/charts/cluster-logging/templates/deploymentEventrouter.yaml
+++ b/charts/cluster-logging/templates/deploymentEventrouter.yaml
@@ -104,7 +104,7 @@ spec:
           imagePullPolicy: IfNotPresent
           {{- if .Values.eventrouter.resources }}
           resources:
-            {{- .Values.eventrouter.resources | nindent 12 -}}
+            {{- .Values.eventrouter.resources | toYaml | nindent 12 -}}
           {{- end }}
           volumeMounts:
           - name: config-volume

--- a/charts/cluster-logging/values-startx.yaml
+++ b/charts/cluster-logging/values-startx.yaml
@@ -34,7 +34,7 @@ logging:
   curation:
     enabled: true
     schedule: "30 3 * * *"
-    resources: |
+    resources:
       limits:
         memory: 256Mi
       requests:
@@ -51,7 +51,7 @@ logging:
 eventrouter:
   enabled: false
   replicas: 1
-  resources: |
+  resources:
     limits:
       cpu: 400m
       memory: 512Mi

--- a/charts/cluster-logging/values-startx.yaml
+++ b/charts/cluster-logging/values-startx.yaml
@@ -7,12 +7,13 @@ context: &context
   component: logging
   app: openshift-logging
 logging:
+  infra: false ## set to true if infra node available
   enabled: true
   managementState: "Managed"
   elasticsearch:
     enabled: true
     replicas: 3
-    resources: |
+    resources:
       limits:
         memory: 16Gi
       requests:
@@ -24,7 +25,7 @@ logging:
   kibana:
     enabled: true
     replicas: 1
-    resources: |
+    resources:
       limits:
         memory: 736Mi
       requests:
@@ -41,7 +42,7 @@ logging:
         memory: 256Mi
   fluentd:
     enabled: true
-    resources: |
+    resources:
       limits:
         memory: 736Mi
       requests:

--- a/charts/cluster-logging/values.schema.json
+++ b/charts/cluster-logging/values.schema.json
@@ -102,7 +102,7 @@
                     "type": "integer"
                 },
                 "resources": {
-                    "type": "string"
+                    "type": "object"
                 }
             }
         },
@@ -124,7 +124,7 @@
                             "type": "boolean"
                         },
                         "resources": {
-                            "type": "string"
+                            "type": "object"
                         },
                         "schedule": {
                             "type": "string"

--- a/charts/cluster-logging/values.schema.json
+++ b/charts/cluster-logging/values.schema.json
@@ -141,7 +141,7 @@
                             "type": "integer"
                         },
                         "resources": {
-                            "type": "string"
+                            "type": "object"
                         },
                         "storage": {
                             "type": "object",
@@ -166,7 +166,7 @@
                             "type": "boolean"
                         },
                         "resources": {
-                            "type": "string"
+                            "type": "object"
                         }
                     }
                 },
@@ -183,7 +183,7 @@
                             "type": "integer"
                         },
                         "resources": {
-                            "type": "string"
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/cluster-logging/values.yaml
+++ b/charts/cluster-logging/values.yaml
@@ -30,7 +30,7 @@ logging:
     # number of elasticsearch instances
     replicas: 3
     # Resource spec for elasticsearch pods
-    resources: |
+    resources:
       limits:
         cpu: 1
         memory: 500Mi
@@ -50,7 +50,7 @@ logging:
     # number of kibana instances
     replicas: 3
     # Resource spec for kibana pods
-    resources: |
+    resources:
       limits:
         cpu: 1
         memory: 500Mi

--- a/charts/cluster-logging/values.yaml
+++ b/charts/cluster-logging/values.yaml
@@ -83,7 +83,7 @@ eventrouter:
   # number of eventrouter instances
   replicas: 1
   # Resource spec for eventrouter pods
-  resources: |
+  resources:
     limits:
       cpu: 400m
       memory: 512Mi

--- a/charts/cluster-quay/values-startx-quay.yaml
+++ b/charts/cluster-quay/values-startx-quay.yaml
@@ -27,6 +27,7 @@ quay:
     email: "cl@startx.fr"
 project: 
   enabled: false
+  infra: true
   context: 
     <<: *context
   project: 

--- a/charts/operator/templates/subscription.yaml
+++ b/charts/operator/templates/subscription.yaml
@@ -30,6 +30,21 @@ spec:
   source: {{ .name | default "redhat-operators" | quote }}
   sourceNamespace: {{ .namespace | default "openshift-marketplace" | quote }}
   {{- end }}
-  startingCSV: "{{ .csv | default $name }}.{{ $version | default "v0.1.0" }}"
-  {{- end }}
+  startingCSV: '{{ .csv | default $name }}.{{ $version | default "v0.1.0" }}'
+  {{- if .config }}
+  config:
+  {{- if .config.infra }}
+    nodeSelector:
+      node-role.kubernetes.io/infra: ''
+    tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/infra
+        operator: Exists
+  {{- end }}{{- /* end condition line 36 */ -}}
+  {{- if .config.env }}
+    env:
+      {{- .config.env | toYaml | nindent 6 }}
+  {{- end }}{{- /* end condition line 44 */ -}}
+  {{- end }}{{- /* end condition line 34 */ -}}
+  {{- end }}{{- /* end condition line 26 */ -}}
 {{- end }}{{- end }}{{- end }}

--- a/charts/operator/values.schema.json
+++ b/charts/operator/values.schema.json
@@ -234,7 +234,20 @@
                                     ]
                                 }
                             }
-                        }
+                        },
+                        "config": {
+                            "type": "object"
+                            "title": "Operator configuration"
+                            "description": "Optional configuration for Operator"
+                            "default": {}
+                            "examples": [
+                                {"infra": true},
+                                {"env": [{
+                                    "name": "FOO"
+                                    "vaue": "bar"
+                                }]}
+                            ]
+                        },
                     }
                 }
             }

--- a/charts/project/templates/project.yaml
+++ b/charts/project/templates/project.yaml
@@ -25,6 +25,12 @@ metadata:
     argocd.argoproj.io/hook: PreSync
     argocd.argoproj.io/hook-delete-policy: HookFailed 
     {{- end }}
+    {{- if .Values.project.infra }}
+    #openshift.io/node-selector: 'node-role.kubernetes.io/infra='
+    scheduler.alpha.kubernetes.io/node-selector: 'node-role.kubernetes.io/infra='
+    scheduler.alpha.kubernetes.io/defaultTolerations: >-
+      [{"operator": "Exists", "effect": "NoSchedule", "key": "node-role.kubernetes.io/infra"}]
+    {{- end }}
     argocd.argoproj.io/sync-wave: "-10"
     openshift.io/node-selector: ""
 spec: {}


### PR DESCRIPTION
Added Tolerations and NodeSelector to different Operator that is supported by Red Hat to be deployed on infrastructure nodes.

The following has been changed:
- project
- operators
- cluster-acm
- cluster-acs
- cluster-quay
- cluster-logging

More may follow, cluster-pipeline instruction are unclear for infrastructure nodes

Cheers~