### PR TITLE
Add cluster-etcdbackup, cluster-kasten, and cluster-trident charts

### DIFF
--- a/charts/cluster-etcdbackup/Chart.lock
+++ b/charts/cluster-etcdbackup/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: project
+  repository: https://helm-repository.readthedocs.io/en/latest/repos/stable
+  version: 21.3.3
+digest: sha256:dd4bd7731b3c4abaaa604ca479b7ff9fc4033f27d333a6a22f6b60e5862b5958
+generated: "2026-05-27T20:19:48.646662261+02:00"

--- a/charts/cluster-etcdbackup/Chart.yaml
+++ b/charts/cluster-etcdbackup/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: etcd-backup
+description: Helm chart used to deploy a CronJob that backs up OpenShift etcd to an S3-compatible object store
+type: application
+version: 21.3.3
+appVersion: "1.0.0"
+icon: https://helm-repository.readthedocs.io/en/latest/img/cluster-backup.svg
+kubeVersion: ">=1.30.0-0"
+keywords:
+  - kubernetes
+  - helm
+  - startx
+  - cluster-chart
+  - cluster
+  - infrastructure
+  - backup
+  - etcd
+  - openshift
+home: https://helm-repository.readthedocs.io/en/latest
+sources:
+  - https://github.com/adfinis/openshift-etcd-backup
+maintainers:
+  - name: "STARTX"
+    email: "dev@startx.fr"
+    url: "https://www.startx.fr"
+
+dependencies:
+  - name: project
+    repository: https://helm-repository.readthedocs.io/en/latest/repos/stable
+    version: "21.3.3"
+    alias: project
+    condition: project.enabled
+
+annotations:
+  category: cluster
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: "GPL-3.0-or-later"
+  artifacthub.io/prerelease: "true"
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Initial release of etcd-backup CronJob chart"
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/cluster-etcdbackup/README.md
+++ b/charts/cluster-etcdbackup/README.md
@@ -1,0 +1,33 @@
+# etcd-backup
+
+Helm chart that deploys a **periodic OpenShift etcd backup CronJob** writing
+to an S3-compatible object store. Uses the [adfinis/openshift-etcd-backup](https://github.com/adfinis/openshift-etcd-backup)
+container image.
+
+## Resources rendered
+
+| Resource | Sync wave | Purpose |
+|---|---|---|
+| `Namespace` (via `project` sub-chart) | 0 | Namespace `etcd-backup` |
+| `ServiceAccount/etcd-backup` | 10 | Identity for the backup pods |
+| `Role/use-privileged-scc` | 10 | Allow `use` on the `privileged` SCC |
+| `RoleBinding/etcd-backup-sa-privileged` | 10 | Bind SA → Role |
+| `ConfigMap/backup-config` | 11 | Non-sensitive S3 settings |
+| `Secret/etcd-backup-s3` | 11 | Sensitive S3 access/secret keys |
+| `ConfigMap/s3-ca` (optional) | 11 | Custom CA bundle when `useS3Ca: true` |
+| `PrometheusRule/etcd-backup-cronjob-monitor` | 12 | "No recent backup" + "Last job failed" alerts |
+| `CronJob/etcd-backup` | 20 | The backup job itself |
+
+## Quick start
+
+```bash
+helm upgrade --install etcd-backup . -f values-startx.yaml -n etcd-backup
+```
+
+## Trigger a backup manually
+
+```bash
+oc -n etcd-backup create job \
+  --from=cronjob/etcd-backup etcd-backup-manual-$(date +%s)
+oc -n etcd-backup logs -f job/etcd-backup-manual-...
+```

--- a/charts/cluster-etcdbackup/templates/NOTES.txt
+++ b/charts/cluster-etcdbackup/templates/NOTES.txt
@@ -1,0 +1,16 @@
+
+Etcd backup is configured with the following characteristics :
+
+-- Context -------------------------
+        scope : {{ include "startx.appScope" . }}
+      cluster : {{ include "startx.appCluster" . }}
+  environment : {{ include "startx.appEnvironment" . }}
+    component : {{ include "startx.appComponent" . }}
+          app : {{ include "startx.appName" . }}
+      version : {{ include "startx.appVersion" . }}
+
+{{ include "etcd-backup.notes" .Values }}
+
+To trigger an on-demand backup (without waiting for the next schedule):
+
+    oc -n {{ .Values.etcdBackup.namespace | default "etcd-backup" }} create job --from=cronjob/etcd-backup etcd-backup-manual-$(date +%s)

--- a/charts/cluster-etcdbackup/templates/_helpers.tpl
+++ b/charts/cluster-etcdbackup/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* Common labels */}}
+{{- define "etcd-backup.labels" -}}
+{{ include "startx.labelsInfra" . }}
+app.kubernetes.io/instance: {{ include "startx.appNameVersion" . | quote }}
+app: etcd
+component: backup
+{{- end -}}
+
+{{/* Common annotations */}}
+{{- define "etcd-backup.annotations" -}}
+{{ include "startx.annotationsInfra" . }}
+{{- end -}}
+
+{{/* Resolve the S3 credentials secret name (inline default or user override) */}}
+{{- define "etcd-backup.s3SecretName" -}}
+{{- if .Values.etcdBackup.s3_secret.secretName -}}
+{{ .Values.etcdBackup.s3_secret.secretName }}
+{{- else -}}
+etcd-backup-s3
+{{- end -}}
+{{- end -}}
+
+{{/* Summary note */}}
+{{- define "etcd-backup.notes" -}}
+-- Etcd Backup ---------------------
+{{- if .etcdBackup }}{{- if .etcdBackup.enabled }}
+    namespace : {{ .etcdBackup.namespace | default "etcd-backup" }}
+     schedule : {{ .etcdBackup.schedule }}
+       bucket : {{ .etcdBackup.s3_bucket_name }} ({{ .etcdBackup.s3_region }})
+     endpoint : {{ .etcdBackup.s3_endpoint }}
+     retention : {{ .etcdBackup.keep_days }}d / {{ .etcdBackup.keep_count }} count
+     alerting : {{ if .etcdBackup.alerting.enabled }}{{ .etcdBackup.alerting.noBackupForHours }}h{{ else }}off{{ end }}
+        S3 CA : {{ if .etcdBackup.useS3Ca }}custom{{ else }}system{{ end }}
+{{- end }}{{- end }}
+{{- end -}}

--- a/charts/cluster-etcdbackup/templates/_startx.tpl
+++ b/charts/cluster-etcdbackup/templates/_startx.tpl
@@ -1,0 +1,142 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+STARTX common helpers
+*/}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "startx.chartNameVersion" -}}
+{{- $name := include "startx.chartName" . -}}
+{{- $version := include "startx.chartVersion" . -}}
+{{- printf "%s-%s" $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the name of the chart.*/}}
+{{- define "startx.chartName" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the version of the chart.*/}}
+{{- define "startx.chartVersion" -}}
+{{- default .Chart.Version .Values.versionOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create application name and version as used by the application label. */}}
+{{- define "startx.appNameVersion" -}}
+{{- $scope := include "startx.appScope" . -}}
+{{- $environment := include "startx.appEnvironment" . -}}
+{{- $name := include "startx.appName" . -}}
+{{- $version := include "startx.appVersion" . -}}
+{{- printf "%s-%s-%s-%s" $scope $environment $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the scope of the application.*/}}
+{{- define "startx.appScope" -}}
+{{- if .Values.context }}
+{{- default "scope" .Values.context.scope | trunc 255 | trimSuffix "-" -}}
+{{- else }}scope
+{{- end }}
+{{- end -}}
+
+{{/* Expand the cluster of the application.*/}}
+{{- define "startx.appCluster" -}}
+{{- if .Values.context }}
+{{- default "cluster" .Values.context.cluster | trunc 255 | trimSuffix "-" -}}
+{{- else }}cluster
+{{- end }}
+{{- end -}}
+
+{{/* Expand the environment of the application.*/}}
+{{- define "startx.appEnvironment" -}}
+{{- if .Values.context }}
+{{- default "environment" .Values.context.environment | trunc 255 | trimSuffix "-" -}}
+{{- else }}environment
+{{- end }}
+{{- end -}}
+
+{{/* Expand the component of the application.*/}}
+{{- define "startx.appComponent" -}}
+{{- if .Values.context }}
+{{- default "component" .Values.context.component | trunc 255 | trimSuffix "-" -}}
+{{- else }}component
+{{- end }}
+{{- end -}}
+
+{{/* Expand the name of the application.*/}}
+{{- define "startx.appName" -}}
+{{- if .Values.context }}
+{{- default .Chart.Name .Values.context.app | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "myapp" .Chart.Name | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Expand the version of the application.*/}}
+{{- define "startx.appVersion" -}}
+{{- if .Values.context }}
+{{- default .Chart.Version .Values.context.version | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "0.0.1" .Chart.Version | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Common annotation for infra charts */}}
+{{- define "startx.annotationsInfra" -}}
+{{ include "startx.annotationsCommon" . }}
+{{- end -}}
+
+{{/* Common annotation for all charts */}}
+{{- define "startx.annotationsCommon" -}}
+openshift.io/generated-by: startx-helm-{{- .Chart.Name | default "mychart" -}}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartxMin" -}}
+app.startx.fr/scope: {{ include "startx.appScope" . | default "scope" | quote }}
+app.startx.fr/cluster: {{ include "startx.appCluster" . | default "cluster" | quote }}
+app.startx.fr/environment: {{ include "startx.appEnvironment" . | default "myenv" | quote }}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartx" -}}
+{{ include "startx.labelsCommonStartxMin" . }}
+app.startx.fr/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.startx.fr/app: {{ include "startx.appName" . | default "myapp" | quote }}
+app.startx.fr/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common minimum kubernetes labels */}}
+{{- define "startx.labelsCommonK8SMin" -}}
+app.kubernetes.io/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.kubernetes.io/part-of: {{ include "startx.appName" . | default "myenv" | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote  }}
+{{- end -}}
+
+{{/* Common kubernetes labels */}}
+{{- define "startx.labelsCommonK8S" -}}
+{{ include "startx.labelsCommonK8SMin" . }}
+app.kubernetes.io/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common helm labels */}}
+{{- define "startx.labelsCommonHelm" -}}
+helm.sh/chart: {{ include "startx.chartName" . | default "mychart" | quote }}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "startx.labelsCommon" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{/* Common infrastructure labels */}}
+{{- define "startx.labelsInfra" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) }}
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/configMap.yaml
+++ b/charts/cluster-etcdbackup/templates/configMap.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backup-config
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-config
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "11"
+data:
+  OCP_BACKUP_S3: "true"
+  OCP_BACKUP_S3_NAME: {{ .Values.etcdBackup.s3_region | quote }}
+  OCP_BACKUP_S3_HOST: {{ .Values.etcdBackup.s3_endpoint | quote }}
+  OCP_BACKUP_S3_BUCKET: {{ .Values.etcdBackup.s3_bucket_name | quote }}
+  OCP_BACKUP_SUBDIR: "/etcd-backup"
+  OCP_BACKUP_DIRNAME: "+etcd-backup-%FT%T%:z"
+  OCP_BACKUP_EXPIRE_TYPE: "days"
+  OCP_BACKUP_KEEP_DAYS: {{ .Values.etcdBackup.keep_days | quote }}
+  OCP_BACKUP_KEEP_COUNT: {{ .Values.etcdBackup.keep_count | quote }}
+  OCP_BACKUP_UMASK: "0027"
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/cronJob.yaml
+++ b/charts/cluster-etcdbackup/templates/cronJob.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+{{- $image := printf "%s:%s" .Values.etcdBackup.image.repository (.Values.etcdBackup.image.tag | default "latest") -}}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-backup
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-cronjob
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "20"
+spec:
+  schedule: {{ .Values.etcdBackup.schedule | quote }}
+  startingDeadlineSeconds: {{ .Values.etcdBackup.startingDeadlineSeconds | default 600 }}
+  successfulJobsHistoryLimit: {{ .Values.etcdBackup.successfulJobsHistoryLimit | default 7 }}
+  failedJobsHistoryLimit: {{ .Values.etcdBackup.failedJobsHistoryLimit | default 3 }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            {{- include "etcd-backup.labels" . | nindent 12 }}
+        spec:
+          serviceAccountName: etcd-backup
+          restartPolicy: Never
+          dnsPolicy: ClusterFirst
+          hostNetwork: true
+          hostPID: true
+          nodeSelector:
+            node-role.kubernetes.io/control-plane: ""
+          tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/master
+              operator: Exists
+          containers:
+            - name: backup-etcd
+              image: {{ $image | quote }}
+              imagePullPolicy: {{ .Values.etcdBackup.image.pullPolicy | default "Always" }}
+              command:
+                - /bin/sh
+                - "-c"
+                - |
+                  set -euo pipefail
+                  {{- if .Values.etcdBackup.useS3Ca }}
+                  echo "Setting up custom CA certificates..."
+                  cp /tmp/s3-ca/ca-bundle.crt /etc/pki/ca-trust/source/anchors/s3-ca-bundle.crt
+                  update-ca-trust extract
+                  echo "CA certificates updated successfully"
+                  {{- end }}
+                  /usr/local/bin/backup.sh
+              {{- if .Values.etcdBackup.useS3Ca }}
+              env:
+                - name: SSL_CERT_FILE
+                  value: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+              {{- end }}
+              envFrom:
+                - configMapRef:
+                    name: backup-config
+                - secretRef:
+                    name: {{ include "etcd-backup.s3SecretName" . | quote }}
+              resources:
+                requests:
+                  cpu: {{ .Values.etcdBackup.resources.requests.cpu | default "500m" | quote }}
+                  memory: {{ .Values.etcdBackup.resources.requests.memory | default "128Mi" | quote }}
+                limits:
+                  cpu: {{ .Values.etcdBackup.resources.limits.cpu | default "1000m" | quote }}
+                  memory: {{ .Values.etcdBackup.resources.limits.memory | default "512Mi" | quote }}
+              securityContext:
+                privileged: true
+                runAsUser: 0
+              volumeMounts:
+                {{- if .Values.etcdBackup.useS3Ca }}
+                - name: s3-ca-cert
+                  mountPath: /tmp/s3-ca
+                  readOnly: true
+                {{- end }}
+                - name: host
+                  mountPath: /host
+          volumes:
+            {{- if .Values.etcdBackup.useS3Ca }}
+            - name: s3-ca-cert
+              configMap:
+                name: s3-ca
+                items:
+                  - key: ca-bundle.crt
+                    path: ca-bundle.crt
+                defaultMode: 420
+            {{- end }}
+            - name: host
+              hostPath:
+                path: /
+                type: Directory
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/prometheusRule.yaml
+++ b/charts/cluster-etcdbackup/templates/prometheusRule.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- if .Values.etcdBackup.alerting.enabled }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+{{- $hours := .Values.etcdBackup.alerting.noBackupForHours | default 24 -}}
+{{- $seconds := mul $hours 3600 -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-backup-cronjob-monitor
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-prometheusrule
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "12"
+spec:
+  groups:
+    - name: etcd-backup
+      rules:
+        # Fire if no successful backup Job completed in the last N hours.
+        # Looks at the most recent successful completion time across all etcd-backup-* Jobs.
+        - alert: EtcdBackupNoRecentSuccess
+          expr: |
+            (time() - max(kube_job_status_completion_time{namespace="{{ $ns }}", job_name=~"etcd-backup.*"})) > {{ $seconds }}
+            or
+            absent(kube_job_status_completion_time{namespace="{{ $ns }}", job_name=~"etcd-backup.*"})
+          for: 10m
+          labels:
+            severity: {{ .Values.etcdBackup.alerting.severity | default "critical" | quote }}
+          annotations:
+            summary: "No successful etcd backup in the last {{ $hours }}h"
+            description: "The etcd-backup CronJob in namespace {{ $ns }} has not produced a successful Job completion in the last {{ $hours }} hours."
+        # Also alert if the latest Job actually failed (orthogonal to the above).
+        - alert: EtcdBackupLastJobFailed
+          expr: |
+            max by (job_name) (kube_job_status_failed{namespace="{{ $ns }}", job_name=~"etcd-backup.*"}) > 0
+          for: 5m
+          labels:
+            severity: {{ .Values.etcdBackup.alerting.severity | default "critical" | quote }}
+          annotations:
+            summary: "Latest etcd-backup Job failed"
+            description: "Job {{`{{ $labels.job_name }}`}} in namespace {{ $ns }} reported a failure."
+{{- end }}
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/s3Ca.yaml
+++ b/charts/cluster-etcdbackup/templates/s3Ca.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- if .Values.etcdBackup.useS3Ca }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: s3-ca
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-s3-ca
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "11"
+data:
+  ca-bundle.crt: |
+{{ .Values.etcdBackup.s3CaCert | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/s3Secret.yaml
+++ b/charts/cluster-etcdbackup/templates/s3Secret.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- if and .Values.etcdBackup.s3_secret.s3_access_key .Values.etcdBackup.s3_secret.s3_secret_key }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "etcd-backup.s3SecretName" . | quote }}
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-s3-secret
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "11"
+stringData:
+  OCP_BACKUP_S3_ACCESS_KEY: {{ .Values.etcdBackup.s3_secret.s3_access_key | quote }}
+  OCP_BACKUP_S3_SECRET_KEY: {{ .Values.etcdBackup.s3_secret.s3_secret_key | quote }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-etcdbackup/templates/serviceAccount.yaml
+++ b/charts/cluster-etcdbackup/templates/serviceAccount.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.etcdBackup.enabled }}
+{{- $ns := .Values.etcdBackup.namespace | default "etcd-backup" -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-backup
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-sa
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "10"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: use-privileged-scc
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-role
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "10"
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    verbs: ["use"]
+    resourceNames: ["privileged"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-backup-sa-privileged
+  namespace: {{ $ns | quote }}
+  labels:
+    {{- include "etcd-backup.labels" . | nindent 4 }}
+    app.kubernetes.io/name: etcd-backup-rolebinding
+  annotations:
+    {{- include "etcd-backup.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "10"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-privileged-scc
+subjects:
+  - kind: ServiceAccount
+    name: etcd-backup
+    namespace: {{ $ns | quote }}
+{{- end }}

--- a/charts/cluster-etcdbackup/values-startx.yaml
+++ b/charts/cluster-etcdbackup/values-startx.yaml
@@ -1,0 +1,62 @@
+# Default values for configuration of a STARTX cluster
+# see values.yaml for explanation of each parameter
+context: &context
+  scope: startx
+  cluster: default
+  environment: infra
+  component: backup
+  app: etcd-backup
+  version: "1.0.0"
+
+etcdBackup:
+  enabled: true
+  namespace: etcd-backup
+  schedule: "0 */12 * * *"
+
+  image:
+    repository: ghcr.io/adfinis/openshift-etcd-backup
+    tag: latest
+    pullPolicy: Always
+
+  resources:
+    requests: { cpu: 500m, memory: 128Mi }
+    limits:   { cpu: 1000m, memory: 512Mi }
+
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  s3_endpoint: ""
+  s3_region: ""
+  s3_bucket_name: ""
+  s3_secret:
+    secretName: ""
+    s3_access_key: "S3_ACCESS_KEY"
+    s3_secret_key: "S3_SECRET_KEY"
+
+  keep_days: 30
+  keep_count: 10
+
+  useS3Ca: false
+  s3CaCert: ""
+
+  alerting:
+    enabled: true
+    noBackupForHours: 24
+    severity: critical
+
+project:
+  enabled: true
+  context:
+    <<: *context
+  project:
+    enabled: true
+    type: namespace
+    name: "etcd-backup"
+    display_name: "Startx Etcd Backup"
+    requester: startx
+    description: Etcd backup namespace configured by STARTX
+  rbac: { enabled: false }
+  networkpolicy: { enabled: false }
+  limits: { enabled: false }
+  quotas: { enabled: false }

--- a/charts/cluster-etcdbackup/values.yaml
+++ b/charts/cluster-etcdbackup/values.yaml
@@ -1,0 +1,91 @@
+# Default values for etcd-backup.
+
+# Application deployment context
+context: &context
+  scope: myscope
+  cluster: default
+  environment: myenv
+  component: backup
+  app: etcd-backup
+  version: "1.0.0"
+
+# Master switch for the etcd-backup CronJob + its supporting resources
+etcdBackup:
+  enabled: false
+  # Namespace where the CronJob, SA, RBAC, ConfigMap, and Secret live.
+  # Used by every sibling template; also fed to the project sub-chart below.
+  namespace: etcd-backup
+
+  # CronJob schedule (every 12h by default)
+  schedule: "0 */12 * * *"
+
+  # Container image
+  image:
+    repository: ghcr.io/adfinis/openshift-etcd-backup
+    tag: latest
+    pullPolicy: Always
+
+  # Resources
+  resources:
+    requests:
+      cpu: 500m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+
+  # CronJob history caps — without these completed Job objects accumulate forever
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+
+  # S3 destination (non-sensitive)
+  s3_endpoint: ""
+  s3_region: ""
+  s3_bucket_name: ""
+
+  # S3 credentials. Two modes:
+  #  1. Inline: leave `secretName` empty and fill `s3_access_key` + `s3_secret_key`.
+  #     The chart will render a Secret named "<release>-etcd-backup-s3" of type Opaque.
+  #  2. External: set `secretName` to an existing Secret in the same namespace
+  #     containing keys `OCP_BACKUP_S3_ACCESS_KEY` and `OCP_BACKUP_S3_SECRET_KEY`.
+  s3_secret:
+    secretName: ""
+    s3_access_key: ""
+    s3_secret_key: ""
+
+  # Retention (passed through to the backup script)
+  keep_days: 30
+  keep_count: 10
+
+  # Custom CA bundle for S3 endpoint (self-signed or private CA)
+  useS3Ca: false
+  # PEM-encoded CA bundle, inserted verbatim into the s3-ca ConfigMap.
+  s3CaCert: ""
+
+  # Alerting — minutes since last successful backup before the alert fires.
+  # The default expression checks for >24h without a success.
+  alerting:
+    enabled: true
+    noBackupForHours: 24
+    severity: critical
+
+# Configuration of the project sub-chart (manages the namespace)
+project:
+  enabled: false
+  context:
+    <<: *context
+  project:
+    enabled: true
+    type: namespace
+    name: "etcd-backup"
+    display_name: "Etcd Backup"
+    description: Etcd backup CronJob namespace configured by startx
+  rbac:
+    enabled: false
+  networkpolicy:
+    enabled: false
+  limits:
+    enabled: false
+  quotas:
+    enabled: false

--- a/charts/cluster-kasten/Chart.lock
+++ b/charts/cluster-kasten/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: project
+  repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+  version: 21.3.0
+- name: operator
+  repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+  version: 21.3.0
+digest: sha256:142943cee946781af2e488243598e0201d9426aa1fed9a5058084e9653ea29ba
+generated: "2026-05-12T20:46:02.9663815+02:00"

--- a/charts/cluster-kasten/Chart.yaml
+++ b/charts/cluster-kasten/Chart.yaml
@@ -1,0 +1,80 @@
+apiVersion: v2
+# Name of this Helm chart
+name: kasten
+# Description of this Helm chart
+description: Helm chart used to configure Kasten K10 (operator + K10 CR) at the cluster level
+# Helm chart application
+type: application
+# Version of this helm chart (see https://github.com/startxfr/helm-repository/blob/dev/README.md for helm chart release guidelines)
+version: 21.3.3
+# Version name of the K10 operator (see https://github.com/startxfr/helm-repository/blob/dev/README.md for helm chart release history)
+appVersion: "8.5.8"
+# Icon of this helm-chart
+icon: https://helm-repository.readthedocs.io/en/latest/img/cluster-backup.svg
+# Kube minimum version
+kubeVersion: ">=1.30.0-0"
+# Keyword list for this chart
+keywords:
+  - kubernetes
+  - helm
+  - startx
+  - cluster-chart
+  - cluster
+  - infrastructure
+  - backup
+  - dr
+  - kasten
+  - k10
+  - veeam
+# STARTX helm chart repository homepage
+home: https://helm-repository.readthedocs.io/en/latest
+# Sources and documentation for this chart
+sources:
+  - https://helm-repository.readthedocs.io/en/latest/charts/kasten
+  - https://github.com/startxfr/helm-repository/tree/master/charts/kasten
+# Main maintainer contact for this helm chart
+maintainers:
+  - name: "STARTX"
+    email: "dev@startx.fr"
+    url: "https://www.startx.fr"
+
+dependencies:
+  - name: project
+    repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+    version: "21.3.0"
+    alias: project
+    condition: project.enabled
+  - name: operator
+    repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+    version: "21.3.0"
+    alias: operator
+    condition: operator.enabled
+
+annotations:
+  # category associated to this package
+  category: cluster
+  # Artifacthub category associated to this package
+  artifacthub.io/category: integration-delivery
+  # Artifacthub license
+  artifacthub.io/license: "GPL-3.0-or-later"
+  # Artifacthub is this release a pre-release
+  artifacthub.io/prerelease: "true"
+  # Artifacthub is an operator chart
+  artifacthub.io/operator: "true"
+  # Artifacthub operator capabilities
+  artifacthub.io/operatorCapabilities: "Seamless Upgrades"
+  # Artifacthub chart recommandations
+  startx.io/recommendations: |
+    - name: Startx basic chart - Project
+      url: https://helm-repository.readthedocs.io/en/latest/charts/project
+    - name: Startx basic chart - Operator
+      url: https://helm-repository.readthedocs.io/en/latest/charts/operator
+  # Artifacthub signing keys
+  artifacthub.io/signKey: |
+    fingerprint: FAC998719FEFFB2E03E119EE0F36B25015D3A34D
+    url: https://helm-repository.readthedocs.io/en/latest/pgp_keys.asc
+  # Artifacthub changes logs
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Initial release of Kasten K10 chart"
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/cluster-kasten/README.md
+++ b/charts/cluster-kasten/README.md
@@ -1,0 +1,34 @@
+# kasten
+
+Helm chart used to deploy and configure **Kasten K10** at the cluster level on OpenShift.
+
+It wires together three pieces:
+
+1. A `project` (namespace `kasten-io` by default) — provided by the `project` sub-chart.
+2. A `Subscription` to the certified `k10-kasten-operator-rhmp` (+ an `OperatorGroup` scoped to `kasten-io`) — provided by the `operator` sub-chart.
+3. The product-specific custom resource rendered by this chart:
+   - `K10` (group `apik10.kasten.io/v1alpha1`) — the K10 instance spec.
+
+## Quick start
+
+```bash
+helm upgrade --install kasten . -f values-startx.yaml
+```
+
+## Values overview
+
+See `values.yaml` for the full list. The most important knobs are:
+
+- `k10.enabled` / `k10.auth.*` — enables the K10 CR and chooses between token / basic auth.
+- `k10.global.persistence.*` — overrides the catalog PVC size and storage class.
+- `k10.route.*` — exposes the K10 dashboard through an OpenShift route (TLS by default).
+- `project.*` — passed straight through to the `project` sub-chart.
+- `operator.*` — passed straight through to the `operator` sub-chart (Subscription + OperatorGroup).
+
+## ArgoCD sync waves
+
+| Resource              | Wave |
+|-----------------------|------|
+| Subscription          | `-5` |
+| Project / Namespace   | `0`  |
+| K10 CR                | `2`  |

--- a/charts/cluster-kasten/templates/NOTES.txt
+++ b/charts/cluster-kasten/templates/NOTES.txt
@@ -1,0 +1,20 @@
+
+Kasten K10 is enabled, at the cluster level, with the following characteristics :
+
+-- Context -------------------------
+        scope : {{ include "startx.appScope" . }}
+      cluster : {{ include "startx.appCluster" . }}
+  environment : {{ include "startx.appEnvironment" . }}
+    component : {{ include "startx.appComponent" . }}
+          app : {{ include "startx.appName" . }}
+      version : {{ include "startx.appVersion" . }}
+
+{{- if .Values.project }}{{- if .Values.project.enabled }}
+{{ include "project.notes" .Values.project }}
+{{- end }}{{- end }}
+
+{{- if .Values.operator }}{{- if .Values.operator.enabled }}
+{{ include "operator.notes" .Values.operator }}
+{{- end }}{{- end }}
+
+{{ include "kasten.notes" .Values }}

--- a/charts/cluster-kasten/templates/_helpers.tpl
+++ b/charts/cluster-kasten/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* STARTX Cluster config helpers */}}
+
+{{/* Common labels */}}
+{{- define "kasten.labels" -}}
+{{ include "startx.labelsInfra" . }}
+app.kubernetes.io/instance: {{ include "startx.appNameVersion" . | quote }}
+{{- end -}}
+
+{{/* Common kasten annotations */}}
+{{- define "kasten.annotations" -}}
+{{ include "startx.annotationsInfra" . }}
+{{- end -}}
+
+{{/* Common operator note */}}
+{{- define "kasten.notes" -}}
+-- Kasten K10 ----------------------
+{{- if .k10 }}{{- if .k10.enabled }}
+{{- $namespace := .project.project.name | default "kasten-io" }}
+          k10 : enabled in {{ $namespace }}
+         name : {{ .k10.name | default "k10" }}
+   tokenAuth : {{ .k10.auth.tokenAuth.enabled | default false }}
+   basicAuth : {{ .k10.auth.basicAuth.enabled | default false }}
+        route : {{ .k10.route.enabled | default false }}{{ if .k10.route.tls.enabled }} (TLS){{ end }}
+{{- end }}{{- end }}
+{{- end -}}

--- a/charts/cluster-kasten/templates/_startx.tpl
+++ b/charts/cluster-kasten/templates/_startx.tpl
@@ -1,0 +1,142 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+STARTX common helpers
+*/}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "startx.chartNameVersion" -}}
+{{- $name := include "startx.chartName" . -}}
+{{- $version := include "startx.chartVersion" . -}}
+{{- printf "%s-%s" $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the name of the chart.*/}}
+{{- define "startx.chartName" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the version of the chart.*/}}
+{{- define "startx.chartVersion" -}}
+{{- default .Chart.Version .Values.versionOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create application name and version as used by the application label. */}}
+{{- define "startx.appNameVersion" -}}
+{{- $scope := include "startx.appScope" . -}}
+{{- $environment := include "startx.appEnvironment" . -}}
+{{- $name := include "startx.appName" . -}}
+{{- $version := include "startx.appVersion" . -}}
+{{- printf "%s-%s-%s-%s" $scope $environment $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the scope of the application.*/}}
+{{- define "startx.appScope" -}}
+{{- if .Values.context }}
+{{- default "scope" .Values.context.scope | trunc 255 | trimSuffix "-" -}}
+{{- else }}scope
+{{- end }}
+{{- end -}}
+
+{{/* Expand the cluster of the application.*/}}
+{{- define "startx.appCluster" -}}
+{{- if .Values.context }}
+{{- default "cluster" .Values.context.cluster | trunc 255 | trimSuffix "-" -}}
+{{- else }}cluster
+{{- end }}
+{{- end -}}
+
+{{/* Expand the environment of the application.*/}}
+{{- define "startx.appEnvironment" -}}
+{{- if .Values.context }}
+{{- default "environment" .Values.context.environment | trunc 255 | trimSuffix "-" -}}
+{{- else }}environment
+{{- end }}
+{{- end -}}
+
+{{/* Expand the component of the application.*/}}
+{{- define "startx.appComponent" -}}
+{{- if .Values.context }}
+{{- default "component" .Values.context.component | trunc 255 | trimSuffix "-" -}}
+{{- else }}component
+{{- end }}
+{{- end -}}
+
+{{/* Expand the name of the application.*/}}
+{{- define "startx.appName" -}}
+{{- if .Values.context }}
+{{- default .Chart.Name .Values.context.app | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "myapp" .Chart.Name | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Expand the version of the application.*/}}
+{{- define "startx.appVersion" -}}
+{{- if .Values.context }}
+{{- default .Chart.Version .Values.context.version | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "0.0.1" .Chart.Version | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Common annotation for infra charts */}}
+{{- define "startx.annotationsInfra" -}}
+{{ include "startx.annotationsCommon" . }}
+{{- end -}}
+
+{{/* Common annotation for all charts */}}
+{{- define "startx.annotationsCommon" -}}
+openshift.io/generated-by: startx-helm-{{- .Chart.Name | default "mychart" -}}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartxMin" -}}
+app.startx.fr/scope: {{ include "startx.appScope" . | default "scope" | quote }}
+app.startx.fr/cluster: {{ include "startx.appCluster" . | default "cluster" | quote }}
+app.startx.fr/environment: {{ include "startx.appEnvironment" . | default "myenv" | quote }}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartx" -}}
+{{ include "startx.labelsCommonStartxMin" . }}
+app.startx.fr/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.startx.fr/app: {{ include "startx.appName" . | default "myapp" | quote }}
+app.startx.fr/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common minimum kubernetes labels */}}
+{{- define "startx.labelsCommonK8SMin" -}}
+app.kubernetes.io/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.kubernetes.io/part-of: {{ include "startx.appName" . | default "myenv" | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote  }}
+{{- end -}}
+
+{{/* Common kubernetes labels */}}
+{{- define "startx.labelsCommonK8S" -}}
+{{ include "startx.labelsCommonK8SMin" . }}
+app.kubernetes.io/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common helm labels */}}
+{{- define "startx.labelsCommonHelm" -}}
+helm.sh/chart: {{ include "startx.chartName" . | default "mychart" | quote }}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "startx.labelsCommon" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{/* Common infrastructure labels */}}
+{{- define "startx.labelsInfra" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) }}
+{{- end }}

--- a/charts/cluster-kasten/templates/k10.yaml
+++ b/charts/cluster-kasten/templates/k10.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.k10 }}
+{{- if .Values.k10.enabled }}
+{{- $name := .Values.k10.name | default "k10" -}}
+{{- $namespace := .Values.project.project.name | default "kasten-io" -}}
+---
+apiVersion: "{{- .Values.k10.apiVersion | default "apik10.kasten.io/v1alpha1" -}}"
+kind: K10
+metadata:
+  name: {{ $name | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "kasten.labels" . | nindent 4 }}
+    app.kubernetes.io/name: "{{ $name }}-k10"
+  annotations:
+    {{- include "kasten.annotations" . | nindent 4 }}
+    {{- if .Values.k10.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  {{- if .Values.k10.auth }}
+  auth:
+    {{- if .Values.k10.auth.openshift }}
+    openshift:
+      enabled: {{ .Values.k10.auth.openshift.enabled | default false }}
+      dashboardURL: {{ .Values.k10.auth.openshift.dashboardURL | default "" | quote }}
+      insecureCA: {{ .Values.k10.auth.openshift.insecureCA | default "false" | quote }}
+      openshiftURL: {{ .Values.k10.auth.openshift.openshiftURL | default "" | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.k10.global }}
+  global:
+    {{- if .Values.k10.global.persistence }}
+    persistence:
+      {{- if .Values.k10.global.persistence.catalog }}
+      catalog:
+        size: {{ .Values.k10.global.persistence.catalog.size | default "" | quote }}
+      {{- end }}
+      storageClass: {{ .Values.k10.global.persistence.storageClass | default "" | quote }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.k10.metering }}
+  metering:
+    mode: {{ .Values.k10.metering.mode | default "" | quote }}
+  {{- end }}
+  {{- if .Values.k10.route }}
+  route:
+    enabled: {{ .Values.k10.route.enabled | default false }}
+    host: {{ .Values.k10.route.host | default "" | quote }}
+    {{- if .Values.k10.route.tls }}
+    tls:
+      enabled: {{ .Values.k10.route.tls.enabled | default false }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-kasten/templates/policy.yaml
+++ b/charts/cluster-kasten/templates/policy.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.policies }}
+{{- if .Values.policies.enabled }}
+{{- $namespace := .Values.project.project.name | default "kasten-io" -}}
+{{- $apiVersion := .Values.policies.apiVersion | default "config.kio.kasten.io/v1alpha1" -}}
+{{- $root := . -}}
+{{- range $idx, $policy := .Values.policies.list }}
+---
+apiVersion: {{ $apiVersion | quote }}
+kind: Policy
+metadata:
+  name: {{ $policy.name | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "kasten.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $policy.name }}-policy"
+  annotations:
+    {{- include "kasten.annotations" $root | nindent 4 }}
+    {{- if $.Values.policies.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "40"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "6"
+spec:
+  {{- if $policy.comment }}
+  comment: {{ $policy.comment | quote }}
+  {{- end }}
+  frequency: {{ $policy.frequency | default "@daily" | quote }}
+  {{- if $policy.paused }}
+  paused: {{ $policy.paused | default false }}
+  {{- end }}
+  actions:
+    - action: backup
+      backupParameters:
+        filters: {}
+        profile:
+          name: {{ $policy.backup.profile.name | quote }}
+          namespace: {{ $policy.backup.profile.namespace | default $namespace | quote }}
+        {{- if $policy.backup.imageRepoProfile }}
+        imageRepoProfile:
+          name: {{ $policy.backup.imageRepoProfile.name | quote }}
+          namespace: {{ $policy.backup.imageRepoProfile.namespace | default $namespace | quote }}
+        {{- end }}
+    {{- if $policy.export }}
+    - action: export
+      exportParameters:
+        frequency: {{ $policy.export.frequency | default $policy.frequency | quote }}
+        profile:
+          name: {{ $policy.export.profile.name | default $policy.backup.profile.name | quote }}
+          namespace: {{ $policy.export.profile.namespace | default $namespace | quote }}
+        exportData:
+          enabled: {{ $policy.export.exportData.enabled | default true }}
+      retention: 
+        {{- if $policy.retention.daily }}
+        daily: {{ $policy.retention.daily | default 0 }}
+        {{- end }}
+        {{- if $policy.retention.weekly }}
+        weekly: {{ $policy.retention.weekly | default 0 }}
+        {{- end }}
+        {{- if $policy.retention.monthly }}
+        monthly: {{ $policy.retention.monthly | default 0 }}
+        {{- end }}
+        {{- if $policy.retention.yearly }}
+        yearly: {{ $policy.retention.yearly | default 0 }}
+        {{- end }}
+        {{- end }}
+  retention: {}
+  selector:
+{{ toYaml $policy.selector | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-kasten/templates/profile.yaml
+++ b/charts/cluster-kasten/templates/profile.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.profiles }}
+{{- if .Values.profiles.enabled }}
+{{- $namespace := .Values.project.project.name | default "kasten-io" -}}
+{{- $apiVersion := .Values.profiles.apiVersion | default "config.kio.kasten.io/v1alpha1" -}}
+{{- $root := . -}}
+{{- range $idx, $profile := .Values.profiles.list }}
+{{- $credential := $profile.locationSpec.credential | default dict -}}
+{{- $secretName := $credential.secretName | default (printf "%s-secret" $profile.name) -}}
+---
+apiVersion: {{ $apiVersion | quote }}
+kind: Profile
+metadata:
+  name: {{ $profile.name | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "kasten.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $profile.name }}-profile"
+  annotations:
+    {{- include "kasten.annotations" $root | nindent 4 }}
+    {{- if $.Values.profiles.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "30"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  type: {{ $profile.type | default "Location" }}
+  locationSpec:
+    type: {{ $profile.locationSpec.type | default "ObjectStore" }}
+    {{- if $profile.locationSpec.objectStore }}
+    objectStore:
+      objectStoreType: {{ $profile.locationSpec.objectStore.objectStoreType | default "S3" }}
+      name: {{ $profile.locationSpec.objectStore.name | quote }}
+      {{- if $profile.locationSpec.objectStore.region }}
+      region: {{ $profile.locationSpec.objectStore.region | quote }}
+      {{- end }}
+      {{- if $profile.locationSpec.objectStore.endpoint }}
+      endpoint: {{ $profile.locationSpec.objectStore.endpoint | quote }}
+      {{- end }}
+      {{- if $profile.locationSpec.objectStore.protectionPeriod }}
+      protectionPeriod: {{ $profile.locationSpec.objectStore.protectionPeriod | quote }}
+      {{- end }}
+      {{- if hasKey $profile.locationSpec.objectStore "skipSSLVerify" }}
+      skipSSLVerify: {{ $profile.locationSpec.objectStore.skipSSLVerify }}
+      {{- end }}
+      {{- if $profile.locationSpec.objectStore.pathType }}
+      pathType: {{ $profile.locationSpec.objectStore.pathType | quote }}
+      {{- end }}
+    {{- end }}
+    credential:
+      secretType: {{ $credential.secretType | default "AwsAccessKey" }}
+      secret:
+        apiVersion: v1
+        kind: Secret
+        name: {{ $secretName | quote }}
+        namespace: "{{- $namespace -}}"
+---
+apiVersion: v1
+kind: Secret
+type: secrets.kanister.io/aws
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "kasten.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $secretName }}-secret"
+  annotations:
+    {{- include "kasten.annotations" $root | nindent 4 }}
+    {{- if $.Values.profiles.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "29"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "4"
+stringData:
+  aws_access_key_id: {{ $credential.awsAccessKeyID | quote }}
+  aws_secret_access_key: {{ $credential.awsSecretAccessKey | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-kasten/values-startx.yaml
+++ b/charts/cluster-kasten/values-startx.yaml
@@ -1,0 +1,81 @@
+# Default values for configuration of a STARTX cluster
+# see values.yaml for explanation on each params
+context: &context
+  scope: startx
+  cluster: default
+  environment: infra
+  component: backup
+  app: kasten
+  version: "8.5.8"
+
+k10:
+  enabled: true
+  hooked: false
+  apiVersion: "apik10.kasten.io/v1alpha1"
+  name: "k10"
+  auth:
+    basicAuth:
+      enabled: false
+      htpasswd: ''
+      secretName: ''
+    tokenAuth:
+      enabled: true
+  global:
+    persistence:
+      catalog:
+        size: ''
+      storageClass: ''
+  metering:
+    mode: ''
+  route:
+    enabled: true
+    host: ''
+    tls:
+      enabled: true
+
+# Configuration of the project (see https://helm-repository.readthedocs.io/en/latest/charts/project)
+project:
+  enabled: true
+  context:
+    <<: *context
+  project:
+    enabled: true
+    type: namespace
+    name: "kasten-io"
+    display_name: "Startx Kasten K10"
+    requester: startx
+    description: Kasten K10 namespace configured by STARTX
+  rbac:
+    enabled: false
+  networkpolicy:
+    enabled: false
+  limits:
+    enabled: false
+  quotas:
+    enabled: false
+
+# Configuration of the operator (see https://helm-repository.readthedocs.io/en/latest/charts/operator)
+operator:
+  enabled: true
+  context:
+    <<: *context
+  subscription:
+    enabled: true
+    hooked: false
+    name: "k10-kasten-operator-rhmp"
+    namespace: "kasten-io"
+    version: "v8.5.8"
+    operator:
+      channel: "stable"
+      name: k10-kasten-operator-rhmp
+      installPlanApproval: Automatic
+      csv: k10-kasten-operator-rhmp
+      source:
+        name: certified-operators
+        namespace: openshift-marketplace
+  operatorGroup:
+    enabled: true
+    hooked: false
+    name: "kasten-io"
+    namespace: "kasten-io"
+    providedAPIs: "K10.v1alpha1.apik10.kasten.io"

--- a/charts/cluster-kasten/values.yaml
+++ b/charts/cluster-kasten/values.yaml
@@ -1,0 +1,182 @@
+# Default values for kasten.
+
+# Application deployment context
+context: &context
+  # Name of the global scope for this application (organisational tenant)
+  scope: myscope
+  # Name of the cluster running this application (plateform tenant)
+  cluster: default
+  # Name of the environement for this application (ex: dev, factory, preprod or prod)
+  environment: myenv
+  # Component name of this application (logical tenant)
+  component: backup
+  # Application name (functionnal tenant, default use Chart name)
+  app: kasten
+  # Version name of this application (default use Chart appVersion)
+  version: "8.5.8"
+
+# Configuration of the K10 instance (the Kasten data-management platform)
+k10:
+  # Enable the deployment of the K10 CR
+  enabled: false
+  # Activate the K10 CR as a helm hook
+  hooked: false
+  # The ApiVersion of the K10 CR
+  apiVersion: "apik10.kasten.io/v1alpha1"
+  # Name of the K10 CR
+  name: "k10"
+  # Authentication settings of the K10 instance
+  auth:
+    basicAuth:
+      enabled: false
+      htpasswd: ''
+      secretName: ''
+    tokenAuth:
+      enabled: true
+  # Global settings (persistence / catalog)
+  global:
+    persistence:
+      catalog:
+        # Size of the catalog PVC. Empty string lets the operator pick its default.
+        size: ''
+      # StorageClass to use for K10 PVCs. Empty string lets the operator pick the cluster default.
+      storageClass: ''
+  # Metering mode (e.g. 'airgap'). Empty string keeps the default behaviour.
+  metering:
+    mode: ''
+  # External exposure of the K10 dashboard
+  route:
+    enabled: true
+    # Hostname to expose. Empty string lets the router compute it.
+    host: ''
+    tls:
+      enabled: true
+# Kasten K10 Policy CRs (backup + optional export schedules).
+# Each entry creates one Policy + an optional Secret holding the
+# migrationToken receiveString (when export is configured).
+policies:
+  # Enable rendering of Policy resources
+  enabled: false
+  # Activate as a helm hook (recommended; the Policy CRD only exists once K10
+  # is up, so creating policies in the same wave as the K10 CR fails on fresh
+  # installs).
+  hooked: true
+  # The ApiVersion of the Policy CR
+  apiVersion: "config.kio.kasten.io/v1alpha1"
+  # List of policies to declare
+  list: []
+  # Example shape (uncomment and adapt in values-startx.yaml or the umbrella):
+  #
+  # list:
+  #   - name: free-pro-infra-backup
+  #     comment: Backup all of openshift namespaces
+  #     frequency: "@daily"
+  #     paused: false
+  #     backup:
+  #       profile:
+  #         name: jso000ac59
+  #         # namespace defaults to project.project.name (kasten-io)
+  #       imageRepoProfile:
+  #         name: jso000ac59
+  #     # Optional second action — replicate backups to a remote profile
+  #     export:
+  #       frequency: "@daily"
+  #       profile:
+  #         name: jso000ac59
+  #       exportData:
+  #         enabled: true
+  #     retention:
+  #       daily: 14
+  #       weekly: 4
+  #       monthly: 0
+  #       yearly: 0
+  #     selector:
+  #       matchExpressions:
+  #         - key: k10.kasten.io/appNamespace
+  #           operator: In
+  #           values:
+  #             - openshift-monitoring
+  #             - openshift-logging
+  #             # ... etc
+profiles:
+  enabled: true
+  hooked: true
+  apiVersion: "config.kio.kasten.io/v1alpha1"
+  list:
+    # - name: jso000ac59
+    #   type: Location
+    #   locationSpec:
+    #     type: ObjectStore
+    #     objectStore:
+    #       objectStoreType: S3
+    #       name: "alcatelsubmarin-veeam-kasten"
+    #       region: "fr-lyo"
+    #       endpoint: "https://s3.fr-lyo.freepro.com"
+    #       protectionPeriod: "360h0m0s"
+    #       # Optional — only set if your endpoint uses a self-signed cert
+    #       # skipSSLVerify: false
+    #       # Optional — only set if your S3 backend requires path-style URLs
+    #       # pathType: "PathTypePathStyle"
+    #     credential:
+    #       secretType: AwsAccessKey
+    #       # MODE 1: leave secretName empty -> Secret named "jso000ac59-secret"
+    #       # MODE 2: set secretName -> Secret named what you chose
+    #       # MODE 3: set secretName AND leave access keys empty -> chart references
+    #       #         an existing Secret without rendering one
+    #       secretName: ""
+    #       awsAccessKeyID: "REPLACE_WITH_S3_ACCESS_KEY"
+    #       awsSecretAccessKey: "REPLACE_WITH_S3_SECRET_KEY"
+# Configuration of the project (see https://helm-repository.readthedocs.io/en/latest/charts/project)
+project:
+  enabled: false
+  context:
+    <<: *context
+  project:
+    enabled: false
+    type: namespace
+    name: "kasten-io"
+    display_name: "Kasten K10"
+    description: Kasten K10 namespace configured by startx
+  rbac:
+    enabled: false
+    groups:
+      - id: devops-view
+        name: devops
+        role: view
+      - id: ops-admin
+        name: ops
+        role: admin
+  networkpolicy:
+    enabled: false
+  limits:
+    enabled: false
+  quotas:
+    enabled: false
+
+# Configuration of the operator (see https://helm-repository.readthedocs.io/en/latest/charts/operator)
+operator:
+  enabled: false
+  context:
+    <<: *context
+  subscription:
+    enabled: true
+    hooked: false
+    name: "k10-kasten-operator-rhmp"
+    namespace: "kasten-io"
+    # Use the "vX.Y.Z" prefix here so the rendered startingCSV is e.g. k10-kasten-operator-rhmp.v8.5.8
+    version: "v8.5.8"
+    operator:
+      channel: "stable"
+      name: k10-kasten-operator-rhmp
+      installPlanApproval: Automatic
+      csv: k10-kasten-operator-rhmp
+      source:
+        name: certified-operators
+        namespace: openshift-marketplace
+  # K10 lives in its own namespace -> we DO need an OperatorGroup here.
+  operatorGroup:
+    enabled: true
+    hooked: false
+    name: "kasten-io"
+    namespace: "kasten-io"
+    providedAPIs: "K10.v1alpha1.apik10.kasten.io"

--- a/charts/cluster-trident/Chart.lock
+++ b/charts/cluster-trident/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: project
+  repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+  version: 21.3.0
+- name: operator
+  repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+  version: 21.3.0
+digest: sha256:142943cee946781af2e488243598e0201d9426aa1fed9a5058084e9653ea29ba
+generated: "2026-05-13T09:42:56.8600158+02:00"

--- a/charts/cluster-trident/Chart.yaml
+++ b/charts/cluster-trident/Chart.yaml
@@ -1,0 +1,80 @@
+apiVersion: v2
+# Name of this Helm chart
+name: trident
+# Description of this Helm chart
+description: Helm chart used to configure NetApp Trident CSI (operator, orchestrator, backend) at the cluster level
+# Helm chart application
+type: application
+# Version of this helm chart (see https://github.com/startxfr/helm-repository/blob/dev/README.md for helm chart release guidelines)
+version: 21.3.3
+# Version name of the trident operator (see https://github.com/startxfr/helm-repository/blob/dev/README.md for helm chart release history)
+appVersion: "26.2.1"
+# Icon of this helm-chart
+icon: https://helm-repository.readthedocs.io/en/latest/img/cluster-storage.svg
+# Kube minimum version
+kubeVersion: ">=1.30.0-0"
+# Keyword list for this chart
+keywords:
+  - kubernetes
+  - helm
+  - startx
+  - cluster-chart
+  - cluster
+  - infrastructure
+  - storage
+  - csi
+  - netapp
+  - trident
+  - ontap
+# STARTX helm chart repository homepage
+home: https://helm-repository.readthedocs.io/en/latest
+# Sources and documentation for this chart
+sources:
+  - https://helm-repository.readthedocs.io/en/latest/charts/trident
+  - https://github.com/startxfr/helm-repository/tree/master/charts/trident
+# Main maintainer contact for this helm chart
+maintainers:
+  - name: "STARTX"
+    email: "dev@startx.fr"
+    url: "https://www.startx.fr"
+
+dependencies:
+  - name: project
+    repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+    version: "21.3.0"
+    alias: project
+    condition: project.enabled
+  - name: operator
+    repository: https://helm-repository.readthedocs.io/en/latest/repos/21/
+    version: "21.3.0"
+    alias: operator
+    condition: operator.enabled
+
+annotations:
+  # category associated to this package
+  category: cluster
+  # Artifacthub category associated to this package
+  artifacthub.io/category: integration-delivery
+  # Artifacthub license
+  artifacthub.io/license: "GPL-3.0-or-later"
+  # Artifacthub is this release a pre-release
+  artifacthub.io/prerelease: "true"
+  # Artifacthub is an operator chart
+  artifacthub.io/operator: "true"
+  # Artifacthub operator capabilities
+  artifacthub.io/operatorCapabilities: "Seamless Upgrades"
+  # Artifacthub chart recommandations
+  startx.io/recommendations: |
+    - name: Startx basic chart - Project
+      url: https://helm-repository.readthedocs.io/en/latest/charts/project
+    - name: Startx basic chart - Operator
+      url: https://helm-repository.readthedocs.io/en/latest/charts/operator
+  # Artifacthub signing keys
+  artifacthub.io/signKey: |
+    fingerprint: FAC998719FEFFB2E03E119EE0F36B25015D3A34D
+    url: https://helm-repository.readthedocs.io/en/latest/pgp_keys.asc
+  # Artifacthub changes logs
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Initial release of NetApp Trident CSI chart"
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/charts/cluster-trident/README.md
+++ b/charts/cluster-trident/README.md
@@ -1,0 +1,38 @@
+# trident
+
+Helm chart used to deploy and configure **NetApp Trident CSI** at the cluster level on OpenShift.
+
+It wires together three pieces:
+
+1. A `project` (namespace `trident` by default) — provided by the `project` sub-chart.
+2. A `Subscription` to the certified `trident-operator` (in `openshift-operators`) — provided by the `operator` sub-chart.
+3. The product-specific custom resources rendered by this chart:
+   - `TridentOrchestrator` — the cluster-wide CSI control-plane spec.
+   - `TridentBackendConfig` — one per declared backend (default: ONTAP-NAS).
+   - `Secret` — credentials for each backend (rendered with `stringData`).
+
+## Quick start
+
+```bash
+helm upgrade --install trident . -f values-startx.yaml
+```
+
+## Values overview
+
+See `values.yaml` for the full list. The most important knobs are:
+
+- `orchestrator.enabled` / `orchestrator.spec.*` — controls the `TridentOrchestrator` CR.
+- `backends.enabled` / `backends.list[*]` — declares one or more `TridentBackendConfig` CRs.
+  Each entry can override `secretName`, `username`, `password`, LIFs, SVM, aggregate, etc.
+- `project.*` — passed straight through to the `project` sub-chart.
+- `operator.*` — passed straight through to the `operator` sub-chart.
+
+## ArgoCD sync waves
+
+| Resource              | Wave |
+|-----------------------|------|
+| Subscription          | `-5` |
+| Project / Namespace   | `0`  |
+| Backend Secret        | `2`  |
+| TridentOrchestrator   | `2`  |
+| TridentBackendConfig  | `3`  |

--- a/charts/cluster-trident/templates/NOTES.txt
+++ b/charts/cluster-trident/templates/NOTES.txt
@@ -1,0 +1,28 @@
+
+NetApp Trident CSI is enabled, at the cluster level, with the following characteristics :
+
+-- Context -------------------------
+        scope : {{ include "startx.appScope" . }}
+      cluster : {{ include "startx.appCluster" . }}
+  environment : {{ include "startx.appEnvironment" . }}
+    component : {{ include "startx.appComponent" . }}
+          app : {{ include "startx.appName" . }}
+      version : {{ include "startx.appVersion" . }}
+
+{{- if .Values.project }}{{- if .Values.project.enabled }}{{- if .Values.project.project }}
+-- Namespace -----------------------
+         name : {{ .Values.project.project.name | default "trident" }}
+ display_name : {{ .Values.project.project.display_name | default "Trident" }}
+         type : {{ .Values.project.project.type | default "namespace" }}
+{{- end }}{{- end }}{{- end }}
+
+{{- if .Values.operator }}{{- if .Values.operator.enabled }}{{- if .Values.operator.subscription }}{{- if .Values.operator.subscription.enabled }}
+-- Subscription --------------------
+         name : {{ .Values.operator.subscription.name }}
+    namespace : {{ .Values.operator.subscription.namespace }}
+      channel : {{ .Values.operator.subscription.operator.channel }}
+       source : {{ .Values.operator.subscription.operator.source.name }} / {{ .Values.operator.subscription.operator.source.namespace }}
+          CSV : {{ .Values.operator.subscription.operator.csv }}.{{ .Values.operator.subscription.version }}
+{{- end }}{{- end }}{{- end }}{{- end }}
+
+{{ include "trident.notes" .Values }}

--- a/charts/cluster-trident/templates/_helpers.tpl
+++ b/charts/cluster-trident/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/* STARTX Cluster config helpers */}}
+
+{{/* Common labels */}}
+{{- define "trident.labels" -}}
+{{ include "startx.labelsInfra" . }}
+app.kubernetes.io/instance: {{ include "startx.appNameVersion" . | quote }}
+{{- end -}}
+
+{{/* Common trident annotations */}}
+{{- define "trident.annotations" -}}
+{{ include "startx.annotationsInfra" . }}
+{{- end -}}
+
+{{/* Common operator note */}}
+{{- define "trident.notes" -}}
+-- Trident -------------------------
+{{- if .orchestrator }}{{- if .orchestrator.enabled }}
+{{- $namespace := .orchestrator.spec.namespace | default "trident" }}
+ orchestrator : enabled in {{ $namespace }}
+         name : {{ .orchestrator.name | default "trident" }}
+        debug : {{ .orchestrator.spec.debug | default false }}
+         IPv6 : {{ .orchestrator.spec.IPv6 | default false }}
+{{- end }}{{- end }}
+{{- if .backends }}{{- if .backends.enabled }}
+{{- $count := len .backends.list }}
+     backends : {{ $count }} declared
+{{- range .backends.list }}
+              - {{ .name }} ({{ .storageDriverName }} @ {{ .managementLIF }})
+{{- end }}
+{{- end }}{{- end }}
+{{- if .storageClasses }}{{- if .storageClasses.enabled }}
+{{- $sccount := len .storageClasses.list }}
+storageclass : {{ $sccount }} declared
+{{- range .storageClasses.list }}
+              - {{ .name }} (reclaim={{ .reclaimPolicy | default "Delete" }}{{ if .isDefault }}, DEFAULT{{ end }})
+{{- end }}
+{{- end }}{{- end }}
+{{- if .volumeSnapshotClasses }}{{- if .volumeSnapshotClasses.enabled }}
+{{- $vsccount := len .volumeSnapshotClasses.list }}
+snapshotclass: {{ $vsccount }} declared
+{{- range .volumeSnapshotClasses.list }}
+              - {{ .name }} (deletion={{ .deletionPolicy | default "Delete" }})
+{{- end }}
+{{- end }}{{- end }}
+{{- end -}}

--- a/charts/cluster-trident/templates/_startx.tpl
+++ b/charts/cluster-trident/templates/_startx.tpl
@@ -1,0 +1,142 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+STARTX common helpers
+*/}}
+
+{{/* Create chart name and version as used by the chart label. */}}
+{{- define "startx.chartNameVersion" -}}
+{{- $name := include "startx.chartName" . -}}
+{{- $version := include "startx.chartVersion" . -}}
+{{- printf "%s-%s" $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the name of the chart.*/}}
+{{- define "startx.chartName" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the version of the chart.*/}}
+{{- define "startx.chartVersion" -}}
+{{- default .Chart.Version .Values.versionOverride | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Create application name and version as used by the application label. */}}
+{{- define "startx.appNameVersion" -}}
+{{- $scope := include "startx.appScope" . -}}
+{{- $environment := include "startx.appEnvironment" . -}}
+{{- $name := include "startx.appName" . -}}
+{{- $version := include "startx.appVersion" . -}}
+{{- printf "%s-%s-%s-%s" $scope $environment $name $version | replace "+" "_" | trunc 255 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Expand the scope of the application.*/}}
+{{- define "startx.appScope" -}}
+{{- if .Values.context }}
+{{- default "scope" .Values.context.scope | trunc 255 | trimSuffix "-" -}}
+{{- else }}scope
+{{- end }}
+{{- end -}}
+
+{{/* Expand the cluster of the application.*/}}
+{{- define "startx.appCluster" -}}
+{{- if .Values.context }}
+{{- default "cluster" .Values.context.cluster | trunc 255 | trimSuffix "-" -}}
+{{- else }}cluster
+{{- end }}
+{{- end -}}
+
+{{/* Expand the environment of the application.*/}}
+{{- define "startx.appEnvironment" -}}
+{{- if .Values.context }}
+{{- default "environment" .Values.context.environment | trunc 255 | trimSuffix "-" -}}
+{{- else }}environment
+{{- end }}
+{{- end -}}
+
+{{/* Expand the component of the application.*/}}
+{{- define "startx.appComponent" -}}
+{{- if .Values.context }}
+{{- default "component" .Values.context.component | trunc 255 | trimSuffix "-" -}}
+{{- else }}component
+{{- end }}
+{{- end -}}
+
+{{/* Expand the name of the application.*/}}
+{{- define "startx.appName" -}}
+{{- if .Values.context }}
+{{- default .Chart.Name .Values.context.app | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "myapp" .Chart.Name | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Expand the version of the application.*/}}
+{{- define "startx.appVersion" -}}
+{{- if .Values.context }}
+{{- default .Chart.Version .Values.context.version | trunc 255 | trimSuffix "-" -}}
+{{- else }}
+{{- default "0.0.1" .Chart.Version | trunc 255 | trimSuffix "-" -}}
+{{- end }}
+{{- end -}}
+
+{{/* Common annotation for infra charts */}}
+{{- define "startx.annotationsInfra" -}}
+{{ include "startx.annotationsCommon" . }}
+{{- end -}}
+
+{{/* Common annotation for all charts */}}
+{{- define "startx.annotationsCommon" -}}
+openshift.io/generated-by: startx-helm-{{- .Chart.Name | default "mychart" -}}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartxMin" -}}
+app.startx.fr/scope: {{ include "startx.appScope" . | default "scope" | quote }}
+app.startx.fr/cluster: {{ include "startx.appCluster" . | default "cluster" | quote }}
+app.startx.fr/environment: {{ include "startx.appEnvironment" . | default "myenv" | quote }}
+{{- end -}}
+
+{{/* Common startx labels */}}
+{{- define "startx.labelsCommonStartx" -}}
+{{ include "startx.labelsCommonStartxMin" . }}
+app.startx.fr/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.startx.fr/app: {{ include "startx.appName" . | default "myapp" | quote }}
+app.startx.fr/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common minimum kubernetes labels */}}
+{{- define "startx.labelsCommonK8SMin" -}}
+app.kubernetes.io/component: {{ include "startx.appComponent" . | default "mycomponent" | quote }}
+app.kubernetes.io/part-of: {{ include "startx.appName" . | default "myenv" | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote  }}
+{{- end -}}
+
+{{/* Common kubernetes labels */}}
+{{- define "startx.labelsCommonK8S" -}}
+{{ include "startx.labelsCommonK8SMin" . }}
+app.kubernetes.io/version: {{ include "startx.appVersion" . | default "0.0.1" | quote }}
+{{- end -}}
+
+{{/* Common helm labels */}}
+{{- define "startx.labelsCommonHelm" -}}
+helm.sh/chart: {{ include "startx.chartName" . | default "mychart" | quote }}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "startx.labelsCommon" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{/* Common infrastructure labels */}}
+{{- define "startx.labelsInfra" -}}
+{{ include "startx.labelsCommonStartx" . }}
+{{ include "startx.labelsCommonHelm" . }}
+{{ include "startx.labelsCommonK8S" . }}
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) }}
+{{- end }}

--- a/charts/cluster-trident/templates/storageClass.yaml
+++ b/charts/cluster-trident/templates/storageClass.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.storageClasses }}
+{{- if .Values.storageClasses.enabled }}
+{{- $root := . -}}
+{{- $provisioner := .Values.storageClasses.provisioner | default "csi.trident.netapp.io" -}}
+{{- $defaultMountOptions := .Values.storageClasses.defaultMountOptions | default (list "nfsvers=3") -}}
+{{- range $idx, $sc := .Values.storageClasses.list }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $sc.name | quote }}
+  labels:
+    {{- include "trident.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $sc.name }}-storageclass"
+  annotations:
+    {{- include "trident.annotations" $root | nindent 4 }}
+    {{- if $sc.isDefault }}
+    storageclass.kubernetes.io/is-default-class: "true"
+    {{- else }}
+    storageclass.kubernetes.io/is-default-class: "false"
+    {{- end }}
+    {{- if $.Values.storageClasses.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "30"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "4"
+provisioner: {{ $provisioner | quote }}
+reclaimPolicy: {{ $sc.reclaimPolicy | default "Delete" }}
+allowVolumeExpansion: {{ $sc.allowVolumeExpansion | default true }}
+volumeBindingMode: {{ $sc.volumeBindingMode | default "Immediate" }}
+mountOptions:
+  {{- if $sc.mountOptions }}
+  {{- range $sc.mountOptions }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range $defaultMountOptions }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+{{- if $sc.parameters }}
+parameters:
+  {{- range $key, $val := $sc.parameters }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-trident/templates/tridentBackendConfig.yaml
+++ b/charts/cluster-trident/templates/tridentBackendConfig.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.backends }}
+{{- if .Values.backends.enabled }}
+{{- $namespace := .Values.orchestrator.spec.namespace | default "trident" -}}
+{{- $apiVersion := .Values.backends.apiVersion | default "trident.netapp.io/v1" -}}
+{{- $root := . -}}
+{{- range $idx, $backend := .Values.backends.list }}
+{{- $secretName := $backend.credentials.secretName | default (printf "%s-secret" $backend.name) }}
+---
+apiVersion: {{ $apiVersion | quote }}
+kind: TridentBackendConfig
+metadata:
+  name: {{ $backend.name | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "trident.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $backend.name }}-tridentbackendconfig"
+  annotations:
+    {{- include "trident.annotations" $root | nindent 4 }}
+    {{- if $.Values.backends.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "20"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "3"
+spec:
+  version: {{ $backend.version | default 1 }}
+  backendName: {{ $backend.backendName | default $backend.name | quote }}
+  storageDriverName: {{ $backend.storageDriverName | default "ontap-nas" | quote }}
+  {{- if $backend.deletionPolicy }}
+  deletionPolicy: {{ $backend.deletionPolicy | quote }}
+  {{- end }}
+  {{- if $backend.nfsMountOptions }}
+  nfsMountOptions: {{ $backend.nfsMountOptions | quote }}
+  {{- end }}
+  {{- if $backend.managementLIF }}
+  managementLIF: {{ $backend.managementLIF | quote }}
+  {{- end }}
+  {{- if $backend.dataLIF }}
+  dataLIF: {{ $backend.dataLIF | quote }}
+  {{- end }}
+  {{- if $backend.svm }}
+  svm: {{ $backend.svm | quote }}
+  {{- end }}
+  {{- if $backend.aggregate }}
+  aggregate: {{ $backend.aggregate | quote }}
+  {{- end }}
+  {{- if hasKey $backend "autoExportPolicy" }}
+  autoExportPolicy: {{ $backend.autoExportPolicy }}
+  {{- end }}
+  {{- if $backend.limitVolumeSize }}
+  limitVolumeSize: {{ $backend.limitVolumeSize | quote }}
+  {{- end }}
+  credentials:
+    name: {{ $secretName | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-trident/templates/tridentBackendSecret.yaml
+++ b/charts/cluster-trident/templates/tridentBackendSecret.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.backends }}
+{{- if .Values.backends.enabled }}
+{{- $namespace := .Values.orchestrator.spec.namespace | default "trident" -}}
+{{- $root := . -}}
+{{- range $idx, $backend := .Values.backends.list }}
+{{- if $backend.credentials }}
+{{- if and $backend.credentials.username $backend.credentials.password }}
+{{- $secretName := $backend.credentials.secretName | default (printf "%s-secret" $backend.name) }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName | quote }}
+  namespace: "{{- $namespace -}}"
+  labels:
+    {{- include "trident.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $secretName }}-secret"
+  annotations:
+    {{- include "trident.annotations" $root | nindent 4 }}
+    argocd.argoproj.io/sync-wave: "2"
+stringData:
+  username: {{ $backend.credentials.username | quote }}
+  password: {{ $backend.credentials.password | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-trident/templates/tridentOrchestrator.yaml
+++ b/charts/cluster-trident/templates/tridentOrchestrator.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.orchestrator }}
+{{- if .Values.orchestrator.enabled }}
+{{- $name := .Values.orchestrator.name | default "trident" -}}
+---
+apiVersion: "{{- .Values.orchestrator.apiVersion | default "trident.netapp.io/v1" -}}"
+kind: TridentOrchestrator
+metadata:
+  name: {{ $name | quote }}
+  labels:
+    {{- include "trident.labels" . | nindent 4 }}
+    app.kubernetes.io/name: "{{ $name }}-tridentorchestrator"
+  annotations:
+    {{- include "trident.annotations" . | nindent 4 }}
+    {{- if .Values.orchestrator.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  IPv6: {{ .Values.orchestrator.spec.IPv6 | default false }}
+  debug: {{ .Values.orchestrator.spec.debug | default false }}
+  enableForceDetach: {{ .Values.orchestrator.spec.enableForceDetach | default false }}
+  silenceAutosupport: {{ .Values.orchestrator.spec.silenceAutosupport | default false }}
+  namespace: {{ .Values.orchestrator.spec.namespace | default "trident" | quote }}
+  imageRegistry: {{ .Values.orchestrator.spec.imageRegistry | default "" | quote }}
+  imagePullSecrets:
+    {{- if .Values.orchestrator.spec.imagePullSecrets }}
+    {{- .Values.orchestrator.spec.imagePullSecrets | toYaml | nindent 4 }}
+    {{- else }} []
+    {{- end }}
+  {{- if .Values.orchestrator.spec.nodePrep }}
+  nodePrep:
+    {{- .Values.orchestrator.spec.nodePrep | toYaml | nindent 4 }}
+  {{- else }}
+  nodePrep: null
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-trident/templates/volumeSnapshotClass.yaml
+++ b/charts/cluster-trident/templates/volumeSnapshotClass.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.volumeSnapshotClasses }}
+{{- if .Values.volumeSnapshotClasses.enabled }}
+{{- $root := . -}}
+{{- $driver := .Values.volumeSnapshotClasses.driver | default "csi.trident.netapp.io" -}}
+{{- range $idx, $vsc := .Values.volumeSnapshotClasses.list }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ $vsc.name | quote }}
+  labels:
+    {{- include "trident.labels" $root | nindent 4 }}
+    app.kubernetes.io/name: "{{ $vsc.name }}-volumesnapshotclass"
+    {{- if $vsc.kastenDefault }}
+    {{- end }}
+  annotations:
+    k10.kasten.io/is-snapshot-class: "true"
+    {{- include "trident.annotations" $root | nindent 4 }}
+    {{- if $vsc.isDefault }}
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+    {{- else }}
+    snapshot.storage.kubernetes.io/is-default-class: "false"
+    {{- end }}
+    {{- if $.Values.volumeSnapshotClasses.hooked }}
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "31"
+    helm.sh/hook-delete-policy: hook-failed
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookFailed
+    {{- end }}
+    argocd.argoproj.io/sync-wave: "4"
+driver: {{ $driver | quote }}
+deletionPolicy: {{ $vsc.deletionPolicy | default "Delete" }}
+{{- if $vsc.parameters }}
+parameters:
+  {{- range $key, $val := $vsc.parameters }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/cluster-trident/values-startx.yaml
+++ b/charts/cluster-trident/values-startx.yaml
@@ -1,0 +1,158 @@
+# Default values for configuration of a STARTX cluster
+# see values.yaml for explanation on each params
+context: &context
+  scope: startx
+  cluster: default
+  environment: infra
+  component: storage
+  app: trident
+  version: "26.2.1"
+
+orchestrator:
+  enabled: true
+  hooked: false
+  apiVersion: "trident.netapp.io/v1"
+  name: "trident"
+  spec:
+    IPv6: false
+    debug: true
+    enableForceDetach: false
+    imagePullSecrets: []
+    imageRegistry: ''
+    namespace: trident
+    nodePrep: null
+    silenceAutosupport: false
+
+backends:
+  enabled: true
+  hooked: false
+  apiVersion: "trident.netapp.io/v1"
+  list:
+    - name: ""
+      backendName: ""
+      storageDriverName: ""
+      version: 1
+      deletionPolicy: retain
+      nfsMountOptions: "nfsvers=3"
+      managementLIF: ""
+      dataLIF: ""
+      svm: ""
+      aggregate: "aggr2"
+      autoExportPolicy: true
+      limitVolumeSize: "...Gi"
+      credentials:
+        secretName: ""
+        username: ""
+        password: ""
+
+storageClasses:
+  enabled: true
+  hooked: false
+  provisioner: "csi.trident.netapp.io"
+  defaultMountOptions:
+    - nfsvers=3
+  list:
+    - name: "ontap-nas-standard"
+      isDefault: true
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "5"
+        splitOnClone: "false"
+        unixPermissions: "0755"
+    - name: "ontap-nas-premium"
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thick"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "10"
+        splitOnClone: "true"
+        unixPermissions: "0755"
+    - name: "ontap-nas-bronze"
+      isDefault: false
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "false"
+        snapshotPolicy: "none"
+        unixPermissions: "0755"
+    - name: "ontap-nas-backup"
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "20"
+        splitOnClone: "false"
+        unixPermissions: "0755"
+
+volumeSnapshotClasses:
+  enabled: true
+  hooked: false
+  driver: "csi.trident.netapp.io"
+  list:
+    - name: "ontap-nas-snapclass"
+      isDefault: true
+      deletionPolicy: Delete
+      kastenDefault: true
+
+# Configuration of the project (see https://helm-repository.readthedocs.io/en/latest/charts/project)
+project:
+  enabled: true
+  context:
+    <<: *context
+  project:
+    enabled: true
+    type: namespace
+    name: "trident"
+    display_name: "Startx Trident"
+    requester: startx
+    description: NetApp Trident CSI namespace configured by STARTX
+  rbac:
+    enabled: false
+  networkpolicy:
+    enabled: false
+  limits:
+    enabled: false
+  quotas:
+    enabled: false
+
+# Configuration of the operator (see https://helm-repository.readthedocs.io/en/latest/charts/operator)
+operator:
+  enabled: true
+  context:
+    <<: *context
+  subscription:
+    enabled: true
+    hooked: false
+    name: "trident-operator"
+    namespace: "openshift-operators"
+    version: "v26.2.1"
+    operator:
+      channel: "stable"
+      name: trident-operator
+      installPlanApproval: Automatic
+      csv: trident-operator
+      source:
+        name: certified-operators
+        namespace: openshift-marketplace
+  # OperatorGroup not needed: 'openshift-operators' already has a global one
+  operatorGroup:
+    enabled: false

--- a/charts/cluster-trident/values.yaml
+++ b/charts/cluster-trident/values.yaml
@@ -1,0 +1,228 @@
+# Default values for trident.
+
+# Application deployment context
+context: &context
+  # Name of the global scope for this application (organisational tenant)
+  scope: myscope
+  # Name of the cluster running this application (plateform tenant)
+  cluster: default
+  # Name of the environement for this application (ex: dev, factory, preprod or prod)
+  environment: myenv
+  # Component name of this application (logical tenant)
+  component: storage
+  # Application name (functionnal tenant, default use Chart name)
+  app: trident
+  # Version name of this application (default use Chart appVersion)
+  version: "26.2.1"
+
+# Configuration of the TridentOrchestrator (deploys the trident control-plane)
+orchestrator:
+  # Enable the deployment of the TridentOrchestrator CR
+  enabled: false
+  # Activate the orchestrator as a helm hook
+  hooked: false
+  # The ApiVersion of the TridentOrchestrator
+  apiVersion: "trident.netapp.io/v1"
+  # Name of the TridentOrchestrator CR
+  name: "trident"
+  # Specifications of the TridentOrchestrator
+  spec:
+    # Enable IPv6
+    IPv6: false
+    # Enable debug logging for trident
+    debug: true
+    # Force-detach volumes from nodes (use with care)
+    enableForceDetach: false
+    # Image pull secrets to use to pull trident images
+    imagePullSecrets: []
+    # Custom image registry to use to pull trident images
+    imageRegistry: ''
+    # Namespace where the trident control-plane will be deployed
+    namespace: trident
+    # nodePrep configuration (set to null to disable)
+    nodePrep: null
+    # Silence autosupport telemetry to NetApp
+    silenceAutosupport: false
+
+# Configuration of a TridentBackendConfig (ONTAP-NAS in this default)
+# Multiple backends can be added; each entry creates one TridentBackendConfig + matching Secret
+backends:
+  # Enable the deployment of TridentBackendConfig CR(s)
+  enabled: false
+  # Activate the backend as a helm hook (deployed after the orchestrator is ready)
+  hooked: false
+  # The ApiVersion of the TridentBackendConfig
+  apiVersion: "trident.netapp.io/v1"
+  # List of backends to declare
+  list:
+    - # Name of the TridentBackendConfig CR
+      name: ""
+      # Friendly name as seen from the backend storage system
+      backendName: ""
+      # Driver to use (ontap-nas, ontap-san, ontap-nas-economy, ...)
+      storageDriverName: ""
+      # Version of the backend config schema
+      version: 1
+      # Deletion policy (retain | delete)
+      deletionPolicy: retain
+      # NFS mount options forwarded to clients
+      nfsMountOptions: "nfsvers=3"
+      # Management LIF (ONTAP cluster mgmt interface)
+      managementLIF: ""
+      # Data LIF (NFS data interface)
+      dataLIF: ""
+      # ONTAP SVM (Storage Virtual Machine) name
+      svm: ""
+      # Aggregate to use for provisioning new volumes
+      aggregate: "aggr2"
+      # Auto-manage export policy
+      autoExportPolicy: true
+      # Hard upper bound on individual volume size
+      limitVolumeSize: "...Gi"
+      # Backend credentials (rendered as a Secret in the trident namespace)
+      credentials:
+        # Name of the secret holding credentials for this backend.
+        # If left empty, defaults to "<backend.name>-secret".
+        secretName: ""
+        # ONTAP/SVM username
+        username: ""
+        # ONTAP/SVM password
+        password: ""
+
+# StorageClasses to create on top of the Trident backend(s).
+# All four classes share the same provisioner and backendType -> they all
+# land on whichever Trident backend matches `backendType: ontap-nas`.
+storageClasses:
+  # Enable rendering of StorageClass resources
+  enabled: false
+  # Activate as a helm hook (runs after the backend is registered)
+  hooked: false
+  # CSI provisioner — always csi.trident.netapp.io for Trident
+  provisioner: "csi.trident.netapp.io"
+  # Default mount options applied to every class unless overridden per item
+  defaultMountOptions:
+    - nfsvers=3
+  # List of storage classes
+  list:
+    # ----- standard (= the cluster default) -----
+    - name: "ontap-nas-standard"
+      isDefault: true
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "5"
+        splitOnClone: "false"
+        unixPermissions: "0755"
+    # ----- premium (Retain + thick, for databases / prod) -----
+    - name: "ontap-nas-premium"
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thick"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "10"
+        splitOnClone: "true"
+        unixPermissions: "0755"
+    # ----- bronze (cheap, no snapshots, for scratch / CI) -----
+    - name: "ontap-nas-bronze"
+      isDefault: false
+      reclaimPolicy: Delete
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "false"
+        snapshotPolicy: "none"
+        unixPermissions: "0755"
+    # ----- backup (large snapshot reserve, Retain, for Kasten / restore data) -----
+    - name: "ontap-nas-backup"
+      isDefault: false
+      reclaimPolicy: Retain
+      allowVolumeExpansion: true
+      volumeBindingMode: Immediate
+      parameters:
+        backendType: "ontap-nas"
+        provisioningType: "thin"
+        snapshots: "true"
+        snapshotPolicy: "default"
+        snapshotReserve: "20"
+        splitOnClone: "false"
+        unixPermissions: "0755"
+
+# VolumeSnapshotClasses — required by Kasten to take CSI snapshots of PVCs.
+volumeSnapshotClasses:
+  enabled: false
+  hooked: false
+  driver: "csi.trident.netapp.io"
+  list:
+    - name: "ontap-nas-snapclass"
+      isDefault: true
+      deletionPolicy: Delete
+      # Optional Kasten label to mark a default snapshotclass it can use
+      kastenDefault: true
+
+# Configuration of the project (see https://helm-repository.readthedocs.io/en/latest/charts/project)
+project:
+  enabled: false
+  context:
+    <<: *context
+  project:
+    enabled: false
+    type: namespace
+    name: "trident"
+    display_name: "Trident"
+    description: NetApp Trident CSI namespace configured by startx
+  rbac:
+    enabled: false
+    groups:
+      - id: devops-view
+        name: devops
+        role: view
+      - id: ops-admin
+        name: ops
+        role: admin
+  networkpolicy:
+    enabled: false
+  limits:
+    enabled: false
+  quotas:
+    enabled: false
+
+# Configuration of the operator (see https://helm-repository.readthedocs.io/en/latest/charts/operator)
+# Default: subscription only, OperatorGroup disabled because the Trident operator
+# is installed in 'openshift-operators' which already provides a global OperatorGroup.
+operator:
+  enabled: false
+  context:
+    <<: *context
+  subscription:
+    enabled: true
+    hooked: false
+    name: "trident-operator"
+    namespace: "openshift-operators"
+    # Use the "vX.Y.Z" prefix here so the rendered startingCSV is e.g. trident-operator.v26.2.1
+    version: "v26.2.1"
+    operator:
+      channel: "stable"
+      name: trident-operator
+      installPlanApproval: Automatic
+      csv: trident-operator
+      source:
+        name: certified-operators
+        namespace: openshift-marketplace
+  operatorGroup:
+    enabled: false
+    hooked: false
+    name: "openshift-operators"
+    namespace: "openshift-operators"
+    providedAPIs: "TridentOrchestrator.v1.trident.netapp.io"


### PR DESCRIPTION
- cluster-etcdbackup: Helm chart that deploys a periodic OpenShift etcd backup CronJob writing to an S3-compatible object store.

- cluster-kasten: Helm chart used to deploy and configure Kasten K10 at the cluster level on OpenShift.

- cluster-trident: Helm chart used to deploy and configure NetApp Trident CSI at the cluster level on OpenShift.